### PR TITLE
Refactor as class and other things

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto
+
+.gitattributes export-ignore
+.gitignore export-ignore
+composer.json export-ignore

--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ Simple plugin that persists the dismissal of admin notices across pages in WordP
 
 Run `composer require collizo4sky/persist-admin-notices-dismissal`
 
-Alternatively, clone or download this repo and include/require the `persist-admin-notices-dismissal.php` file like so
+Alternatively, clone or download this repo into the `vendor/` folder in your plugin, and include/require the `persist-admin-notices-dismissal.php` file like so
 
 ```
-require 'persist-admin-notices-dismissal.php'
+include  __DIR__ . '/vendor/persist-admin-notices-dismissal/persist-admin-notices-dismissal.php'
 ```
 
 ## How to Use
-Firstly, install and activate this library as a plugin by cloning / downloading to your WordPress `wp-content/plugins` directory.
+Firstly, install and activate this library within a plugin.
 
 Say you have the following markup as your admin notice
 
@@ -46,10 +46,10 @@ add_action( 'admin_notices', 'sample_admin_notice__success' );
 ```
 
 
-**Note:** the `data-dismissible` attribute must have a unique hypen separated text prefixed by `data-` which will serve as the key or option name used by the Options API to persist the state to the database. Don't understand, see the following examples.
+**Note:** the `data-dismissible` attribute must have a unique hyphen separated text prefixed by `data-` which will serve as the key or option name used by the Options API to persist the state to the database. Don't understand, see the following examples.
 
 #### Examples
-Say you have two notices displayed when certain actions are triggered; firsly, choose a string to uniquely identify them. E.g `data-notice-one` and `data-notice-two`
+Say you have two notices displayed when certain actions are triggered; firstly, choose a string to uniquely identify theme, e.g. `data-notice-one` and `data-notice-two`
 
 To make the first notice never appear forever when dismissed, its `data-dismissible` attribute will be `data-dismissible="data-notice-one-forever"` where `data-notice-one` is its unique identifier.
 
@@ -60,7 +60,8 @@ To actually make the dismissed admin notice not to appear, use the `is_admin_not
 
 ```
 function sample_admin_notice__success1() {
-    if ( ! is_admin_notice_active( 'data-notice-one-forever' ) ) {
+	$PAnD = new PAnD();
+    if ( ! $PAnD->is_admin_notice_active( 'data-notice-one-forever' ) ) {
         return;
     }
 
@@ -75,12 +76,13 @@ add_action( 'admin_notices', 'sample_admin_notice__success1' );
 
 ```
 function sample_admin_notice__success2() {
-    if ( ! is_admin_notice_active( 'data-notice-two-2' ) ) {
+	$PAnD = new PAnD();
+	if ( ! $PAnD->is_admin_notice_active( 'data-notice-two-2' ) ) {
         return;
     }
 
-    ?>
-    <div data-dismissible="data-notice-two-2" class="updated notice notice-success is-dismissible">
+	?>
+	<div data-dismissible="data-notice-two-2" class="updated notice notice-success is-dismissible">
         <p><?php _e( 'Done 2!', 'sample-text-domain' ); ?></p>
     </div>
     <?php

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Latest Stable Version](https://poser.pugx.org/collizo4sky/persist-admin-notices-dismissal/v/stable)](https://packagist.org/packages/collizo4sky/persist-admin-notices-dismissal)
 [![Total Downloads](https://poser.pugx.org/collizo4sky/persist-admin-notices-dismissal/downloads)](https://packagist.org/packages/collizo4sky/persist-admin-notices-dismissal)
 
-Simple plugin that persists the dismissal of admin notices across pages in WordPress dashboard.
+Simple framework library that persists the dismissal of admin notices across pages in WordPress dashboard.
 
 ## Installation
 
@@ -14,10 +14,12 @@ Alternatively, clone or download this repo into the `vendor/` folder in your plu
 include  __DIR__ . '/vendor/persist-admin-notices-dismissal/persist-admin-notices-dismissal.php'
 ```
 
+or let Composer's autoloader do the work.
+
 ## How to Use
 Firstly, install and activate this library within a plugin.
 
-Say you have the following markup as your admin notice
+Say you have the following markup as your admin notice,
 
 
 ```

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ add_action( 'admin_notices', 'sample_admin_notice__success' );
 ## Autoloaders
 When using the framework with an autoloader you **must** also load the class outside of the `admin_notices` or `network_admin_notices` hooks. The reason is that these hooks come after the `admin_enqueue_script` hook that loads the javascript.
 
-Add the following in your plugin.
+Add the following in your main plugin.
 
 ```
 add_action( 'admin_init', array( PAnD::instance(), 'init' ) );

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Alternatively, clone or download this repo into the `vendor/` folder in your plu
 
 ```
 require  __DIR__ . '/vendor/persist-admin-notices-dismissal/persist-admin-notices-dismissal.php'
-add_action( 'admin_init', array( PAnD::instance(), 'init' ) );
+add_action( 'admin_init', array( 'PAnD', 'init' ) );
 ```
 
 or let Composer's autoloader do the work.
@@ -45,7 +45,7 @@ function sample_admin_notice__success() {
 	</div>
 	<?php
 }
-add_action( 'admin_init', array( PAnD::instance(), 'init' ) );
+add_action( 'admin_init', array( 'PAnD', 'init' ) );
 add_action( 'admin_notices', 'sample_admin_notice__success' );
 ```
 
@@ -55,7 +55,7 @@ When using the framework with an autoloader you **must** also load the class out
 Just add the following in your main plugin file.
 
 ```
-add_action( 'admin_init', array( PAnD::instance(), 'init' ) );
+add_action( 'admin_init', array( 'PAnD', 'init' ) );
 ```
  
 **Note:** the `data-dismissible` attribute must have a unique hyphen separated text prefixed by `data-` which will serve as the key or option name used by the Options API to persist the state to the database. Don't understand, see the following examples.
@@ -83,7 +83,7 @@ function sample_admin_notice__success1() {
 	<?php
 }
 
-add_action( 'admin_init', array( PAnD::instance(), 'init' ) );
+add_action( 'admin_init', array( 'PAnD', 'init' ) );
 add_action( 'admin_notices', 'sample_admin_notice__success1' );
 ```
 
@@ -100,7 +100,7 @@ function sample_admin_notice__success2() {
 	<?php
 }
 
-add_action( 'admin_init', array( PAnD::instance(), 'init' ) );
+add_action( 'admin_init', array( 'PAnD', 'init' ) );
 add_action( 'admin_notices', 'sample_admin_notice__success2' );
 ```
 

--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ Say you have the following markup as your admin notice,
 
 ```
 function sample_admin_notice__success() {
-?>
-<div class="updated notice notice-success is-dismissible">
-    <p><?php _e( 'Done!', 'sample-text-domain' ); ?></p>
-</div>
-<?php
+	?>
+	<div class="updated notice notice-success is-dismissible">
+    	<p><?php _e( 'Done!', 'sample-text-domain' ); ?></p>
+	</div>
+	<?php
 }
 add_action( 'admin_notices', 'sample_admin_notice__success' );
 ```
@@ -38,11 +38,11 @@ To make it hidden forever when dismissed, add the following data attribute `data
 
 ```
 function sample_admin_notice__success() {
-    ?>
-    <div data-dismissible="data-disable-done-notice-forever" class="updated notice notice-success is-dismissible">
-        <p><?php _e( 'Done!', 'sample-text-domain' ); ?></p>
-    </div>
-    <?php
+	?>
+	<div data-dismissible="data-disable-done-notice-forever" class="updated notice notice-success is-dismissible">
+		<p><?php _e( 'Done!', 'sample-text-domain' ); ?></p>
+	</div>
+	<?php
 }
 add_action( 'admin_notices', 'sample_admin_notice__success' );
 ```
@@ -63,15 +63,15 @@ To actually make the dismissed admin notice not to appear, use the `is_admin_not
 ```
 function sample_admin_notice__success1() {
 	$PAnD = new PAnD();
-    if ( ! $PAnD->is_admin_notice_active( 'data-notice-one-forever' ) ) {
-        return;
-    }
+	if ( ! $PAnD->is_admin_notice_active( 'data-notice-one-forever' ) ) {
+		return;
+	}
 
-    ?>
-    <div data-dismissible="data-notice-one-forever" class="updated notice notice-success is-dismissible">
-        <p><?php _e( 'Done 1!', 'sample-text-domain' ); ?></p>
-    </div>
-    <?php
+	?>
+	<div data-dismissible="data-notice-one-forever" class="updated notice notice-success is-dismissible">
+		<p><?php _e( 'Done 1!', 'sample-text-domain' ); ?></p>
+	</div>
+	<?php
 }
 add_action( 'admin_notices', 'sample_admin_notice__success1' );
 ```
@@ -80,14 +80,14 @@ add_action( 'admin_notices', 'sample_admin_notice__success1' );
 function sample_admin_notice__success2() {
 	$PAnD = new PAnD();
 	if ( ! $PAnD->is_admin_notice_active( 'data-notice-two-2' ) ) {
-        return;
-    }
+		return;
+	}
 
 	?>
 	<div data-dismissible="data-notice-two-2" class="updated notice notice-success is-dismissible">
-        <p><?php _e( 'Done 2!', 'sample-text-domain' ); ?></p>
-    </div>
-    <?php
+		<p><?php _e( 'Done 2!', 'sample-text-domain' ); ?></p>
+	</div>
+	<?php
 }
 add_action( 'admin_notices', 'sample_admin_notice__success2' );
 ```

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Alternatively, clone or download this repo into the `vendor/` folder in your plu
 
 ```
 include  __DIR__ . '/vendor/persist-admin-notices-dismissal/persist-admin-notices-dismissal.php'
+add_action( 'admin_init', array( PAnD::instance(), 'init' ) );
 ```
 
 or let Composer's autoloader do the work.
@@ -50,7 +51,7 @@ add_action( 'admin_notices', 'sample_admin_notice__success' );
 ## Autoloaders
 When using the framework with an autoloader you **must** also load the class outside of the `admin_notices` or `network_admin_notices` hooks. The reason is that these hooks come after the `admin_enqueue_script` hook that loads the javascript.
 
-Add the following in your main plugin.
+Just add the following in your main plugin.
 
 ```
 add_action( 'admin_init', array( PAnD::instance(), 'init' ) );

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ add_action( 'admin_notices', 'sample_admin_notice__success' );
 **Note:** the `data-dismissible` attribute must have a unique hyphen separated text prefixed by `data-` which will serve as the key or option name used by the Options API to persist the state to the database. Don't understand, see the following examples.
 
 #### Examples
-Say you have two notices displayed when certain actions are triggered; firstly, choose a string to uniquely identify theme, e.g. `data-notice-one` and `data-notice-two`
+Say you have two notices displayed when certain actions are triggered; firstly, choose a string to uniquely identify them, e.g. `data-notice-one` and `data-notice-two`
 
 To make the first notice never appear forever when dismissed, its `data-dismissible` attribute will be `data-dismissible="data-notice-one-forever"` where `data-notice-one` is its unique identifier.
 

--- a/README.md
+++ b/README.md
@@ -70,8 +70,7 @@ To actually make the dismissed admin notice not to appear, use the `is_admin_not
 
 ```
 function sample_admin_notice__success1() {
-	$PAnD = new PAnD();
-	if ( ! $PAnD->is_admin_notice_active( 'data-notice-one-forever' ) ) {
+	if ( ! PAnD::instance()->is_admin_notice_active( 'data-notice-one-forever' ) ) {
 		return;
 	}
 
@@ -88,8 +87,7 @@ add_action( 'admin_notices', 'sample_admin_notice__success1' );
 
 ```
 function sample_admin_notice__success2() {
-	$PAnD = new PAnD();
-	if ( ! $PAnD->is_admin_notice_active( 'data-notice-two-2' ) ) {
+	if ( ! PAnD::instance()->is_admin_notice_active( 'data-notice-two-2' ) ) {
 		return;
 	}
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Run `composer require collizo4sky/persist-admin-notices-dismissal`
 Alternatively, clone or download this repo into the `vendor/` folder in your plugin, and include/require the `persist-admin-notices-dismissal.php` file like so
 
 ```
-include  __DIR__ . '/vendor/persist-admin-notices-dismissal/persist-admin-notices-dismissal.php'
+require  __DIR__ . '/vendor/persist-admin-notices-dismissal/persist-admin-notices-dismissal.php'
 add_action( 'admin_init', array( PAnD::instance(), 'init' ) );
 ```
 
@@ -72,7 +72,7 @@ To actually make the dismissed admin notice not to appear, use the `is_admin_not
 
 ```
 function sample_admin_notice__success1() {
-	if ( ! PAnD::instance()->is_admin_notice_active( 'data-notice-one-forever' ) ) {
+	if ( ! PAnD::is_admin_notice_active( 'data-notice-one-forever' ) ) {
 		return;
 	}
 
@@ -89,7 +89,7 @@ add_action( 'admin_notices', 'sample_admin_notice__success1' );
 
 ```
 function sample_admin_notice__success2() {
-	if ( ! PAnD::instance()->is_admin_notice_active( 'data-notice-two-2' ) ) {
+	if ( ! PAnD::is_admin_notice_active( 'data-notice-two-2' ) ) {
 		return;
 	}
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ add_action( 'admin_notices', 'sample_admin_notice__success' );
 ## Autoloaders
 When using the framework with an autoloader you **must** also load the class outside of the `admin_notices` or `network_admin_notices` hooks. The reason is that these hooks come after the `admin_enqueue_script` hook that loads the javascript.
 
-Just add the following in your main plugin.
+Just add the following in your main plugin file.
 
 ```
 add_action( 'admin_init', array( PAnD::instance(), 'init' ) );
@@ -65,7 +65,7 @@ Say you have two notices displayed when certain actions are triggered; firstly, 
 
 To make the first notice never appear forever when dismissed, its `data-dismissible` attribute will be `data-dismissible="data-notice-one-forever"` where `data-notice-one` is its unique identifier.
 
-To make the second notice only hidden for 2 days, its `data-dismissible` attribute will be `data-dismissible="data-notice-two-2"` where `data-notice-one` is its unique identifier and the `2` the number of days it will be hidden.
+To make the second notice only hidden for 2 days, its `data-dismissible` attribute will be `data-dismissible="data-notice-two-2"` where `data-notice-two` is its unique identifier and the `2` the number of days it will be hidden.
 
 To actually make the dismissed admin notice not to appear, use the `is_admin_notice_active()` function like so:
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,17 @@ function sample_admin_notice__success() {
 add_action( 'admin_notices', 'sample_admin_notice__success' );
 ```
 
+## Autoloaders
+When using the framework with an autoloader you **must** also load the class outside of the `admin_notices` or `network_admin_notices` hooks. The reason is that these hooks come after the `admin_enqueue_script` hook that loads the javascript.
 
+Add the following in your plugin.
+
+```
+add_action( 'admin_init', function() {
+	new PAnD();
+});
+```
+ 
 **Note:** the `data-dismissible` attribute must have a unique hyphen separated text prefixed by `data-` which will serve as the key or option name used by the Options API to persist the state to the database. Don't understand, see the following examples.
 
 #### Examples
@@ -73,6 +83,10 @@ function sample_admin_notice__success1() {
 	</div>
 	<?php
 }
+
+add_action( 'admin_init', function() {
+	new PAnD();
+});
 add_action( 'admin_notices', 'sample_admin_notice__success1' );
 ```
 
@@ -89,6 +103,10 @@ function sample_admin_notice__success2() {
 	</div>
 	<?php
 }
+
+add_action( 'admin_init', function() {
+	new PAnD();
+});
 add_action( 'admin_notices', 'sample_admin_notice__success2' );
 ```
 

--- a/README.md
+++ b/README.md
@@ -53,9 +53,7 @@ When using the framework with an autoloader you **must** also load the class out
 Add the following in your plugin.
 
 ```
-add_action( 'admin_init', function() {
-	new PAnD();
-});
+add_action( 'admin_init', array( PAnD::instance(), 'init' ) );
 ```
  
 **Note:** the `data-dismissible` attribute must have a unique hyphen separated text prefixed by `data-` which will serve as the key or option name used by the Options API to persist the state to the database. Don't understand, see the following examples.
@@ -84,9 +82,7 @@ function sample_admin_notice__success1() {
 	<?php
 }
 
-add_action( 'admin_init', function() {
-	new PAnD();
-});
+add_action( 'admin_init', array( PAnD::instance(), 'init' ) );
 add_action( 'admin_notices', 'sample_admin_notice__success1' );
 ```
 
@@ -104,9 +100,7 @@ function sample_admin_notice__success2() {
 	<?php
 }
 
-add_action( 'admin_init', function() {
-	new PAnD();
-});
+add_action( 'admin_init', array( PAnD::instance(), 'init' ) );
 add_action( 'admin_notices', 'sample_admin_notice__success2' );
 ```
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ function sample_admin_notice__success() {
 	</div>
 	<?php
 }
+add_action( 'admin_init', array( PAnD::instance(), 'init' ) );
 add_action( 'admin_notices', 'sample_admin_notice__success' );
 ```
 

--- a/dismiss-notice.js
+++ b/dismiss-notice.js
@@ -20,7 +20,7 @@
                 'dismissible_length': dismissible_length,
                 'nonce': dismissible_notice.nonce
             };
-            
+
             // We can also pass the url value separately from ajaxurl for front end AJAX implementations
             $.post(ajaxurl, data);
         });

--- a/persist-admin-notices-dismissal.php
+++ b/persist-admin-notices-dismissal.php
@@ -59,7 +59,7 @@ if ( ! class_exists( 'PAnD' ) ) {
 		 */
 		public function load_script() {
 			wp_enqueue_script( 'dismissible-notices',
-				plugin_dir_url( __FILE__ ) . 'dismiss-notice.js',
+				plugin_url( 'dismiss-notice.js', __FILE__ ),
 				array( 'jquery', 'common' ),
 				false,
 				true

--- a/persist-admin-notices-dismissal.php
+++ b/persist-admin-notices-dismissal.php
@@ -27,28 +27,6 @@ if ( ! class_exists( 'PAnD' ) ) {
 
 	class PAnD {
 
-		public function __construct() {
-
-			/**
-			 * Enqueue javascript and register tags.
-			 */
-			add_action( 'admin_enqueue_scripts', function () {
-				wp_enqueue_script( 'dismissible-notices',
-					plugin_dir_url( __FILE__ ) . 'dismiss-notice.js',
-					array( 'jquery', 'common' ),
-					false,
-					true
-				);
-
-				wp_localize_script( 'dismissible-notices', 'dismissible_notice',
-					array(
-						'nonce' => wp_create_nonce( 'dismissible-notice' ),
-					)
-				);
-			} );
-
-		}
-
 		/**
 		 * Is admin notice active?
 		 *
@@ -75,6 +53,24 @@ if ( ! class_exists( 'PAnD' ) ) {
 	}
 
 }
+
+/**
+ * Enqueue javascript and register tags.
+ */
+add_action( 'admin_enqueue_scripts', function () {
+	wp_enqueue_script( 'dismissible-notices',
+		plugin_dir_url( __FILE__ ) . 'dismiss-notice.js',
+		array( 'jquery', 'common' ),
+		false,
+		true
+	);
+
+	wp_localize_script( 'dismissible-notices', 'dismissible_notice',
+		array(
+			'nonce' => wp_create_nonce( 'dismissible-notice' ),
+		)
+	);
+} );
 
 /**
  * Handles Ajax request to persist notices dismissal.

--- a/persist-admin-notices-dismissal.php
+++ b/persist-admin-notices-dismissal.php
@@ -23,6 +23,20 @@
  * @license http://www.gnu.org/licenses GNU General Public License
  */
 
+/**
+ * Exit if called directly.
+ */
+if ( ! defined( 'WPINC' ) ) {
+	die;
+}
+
+/**
+ * Don't run during heartbeat.
+ */
+if ( isset( $_REQUEST['action'] ) && 'heartbeat' === $_REQUEST['action'] ) {
+	return false;
+}
+
 if ( ! class_exists( 'PAnD' ) ) {
 
 	/**

--- a/persist-admin-notices-dismissal.php
+++ b/persist-admin-notices-dismissal.php
@@ -47,9 +47,29 @@ if ( ! class_exists( 'PAnD' ) ) {
 	class PAnD {
 
 		/**
-		 * PAnD constructor.
+		 * Singleton variable.
+		 *
+		 * @var bool
 		 */
-		public function __construct() {
+		private static $instance = false;
+
+		/**
+		 * Singleton.
+		 *
+		 * @return bool|\PAnD
+		 */
+		public static function instance() {
+			if ( false === self::$instance ) {
+				self::$instance = new self();
+			}
+
+			return self::$instance;
+		}
+
+		/**
+		 * Init hooks.
+		 */
+		public function init() {
 			add_action( 'admin_enqueue_scripts', array( $this, 'load_script' ) );
 			add_action( 'wp_ajax_dismiss_admin_notice', array( $this, 'dismiss_admin_notice' ) );
 		}
@@ -119,5 +139,3 @@ if ( ! class_exists( 'PAnD' ) ) {
 	}
 
 }
-
-new PAnD();

--- a/persist-admin-notices-dismissal.php
+++ b/persist-admin-notices-dismissal.php
@@ -60,7 +60,7 @@ if ( ! class_exists( 'PAnD' ) ) {
 		public function load_script() {
 			wp_enqueue_script(
 				'dismissible-notices',
-				plugin_url( 'dismiss-notice.js', __FILE__ ),
+				plugins_url( 'dismiss-notice.js', __FILE__ ),
 				array( 'jquery', 'common' ),
 				false,
 				true

--- a/persist-admin-notices-dismissal.php
+++ b/persist-admin-notices-dismissal.php
@@ -119,7 +119,7 @@ if ( ! class_exists( 'PAnD' ) ) {
 		 *
 		 * @return bool
 		 */
-		public function is_admin_notice_active( $arg ) {
+		public static function is_admin_notice_active( $arg ) {
 			$array       = explode( '-', $arg );
 			$length      = array_pop( $array );
 			$option_name = implode( '-', $array );

--- a/persist-admin-notices-dismissal.php
+++ b/persist-admin-notices-dismissal.php
@@ -47,25 +47,6 @@ if ( ! class_exists( 'PAnD' ) ) {
 				);
 			} );
 
-
-			/**
-			 * Handles Ajax request to persist notices dismissal.
-			 */
-			add_action( 'wp_ajax_dismiss_admin_notice', function () {
-				$option_name        = sanitize_text_field( $_POST['option_name'] );
-				$dismissible_length = sanitize_text_field( $_POST['dismissible_length'] );
-
-				if ( 'forever' != $dismissible_length ) {
-					$dismissible_length = time() + strtotime( absint( $dismissible_length ) . 'days' );
-				}
-
-				if ( wp_verify_nonce( $_REQUEST['nonce'], 'pp-dismissible-notice' ) && false !== strpos( $option_name, 'data-' ) ) {
-					add_option( $option_name, $dismissible_length );
-				}
-
-				add_option( $option_name, $dismissible_length );
-				wp_die();
-			} );
 		}
 
 		/**
@@ -93,5 +74,23 @@ if ( ! class_exists( 'PAnD' ) ) {
 
 	}
 
-	new PAnD();
 }
+
+/**
+ * Handles Ajax request to persist notices dismissal.
+ */
+add_action( 'wp_ajax_dismiss_admin_notice', function () {
+	$option_name        = sanitize_text_field( $_POST['option_name'] );
+	$dismissible_length = sanitize_text_field( $_POST['dismissible_length'] );
+
+	if ( 'forever' != $dismissible_length ) {
+		$dismissible_length = time() + strtotime( absint( $dismissible_length ) . 'days' );
+	}
+
+	if ( wp_verify_nonce( $_REQUEST['nonce'], 'pp-dismissible-notice' ) && false !== strpos( $option_name, 'data-' ) ) {
+		add_option( $option_name, $dismissible_length );
+	}
+
+	add_option( $option_name, $dismissible_length );
+	wp_die();
+} );

--- a/persist-admin-notices-dismissal.php
+++ b/persist-admin-notices-dismissal.php
@@ -58,14 +58,17 @@ if ( ! class_exists( 'PAnD' ) ) {
 		 * Enqueue javascript and variables.
 		 */
 		public function load_script() {
-			wp_enqueue_script( 'dismissible-notices',
+			wp_enqueue_script(
+				'dismissible-notices',
 				plugin_url( 'dismiss-notice.js', __FILE__ ),
 				array( 'jquery', 'common' ),
 				false,
 				true
 			);
 
-			wp_localize_script( 'dismissible-notices', 'dismissible_notice',
+			wp_localize_script(
+				'dismissible-notices',
+				'dismissible_notice',
 				array(
 					'nonce' => wp_create_nonce( 'PAnD-dismissible-notice' ),
 				)

--- a/persist-admin-notices-dismissal.php
+++ b/persist-admin-notices-dismissal.php
@@ -36,7 +36,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Don't run during heartbeat.
  */
 if ( isset( $_REQUEST['action'] ) && 'heartbeat' === $_REQUEST['action'] ) {
-	return false;
+	return;
 }
 
 if ( ! class_exists( 'PAnD' ) ) {

--- a/persist-admin-notices-dismissal.php
+++ b/persist-admin-notices-dismissal.php
@@ -83,10 +83,9 @@ add_action( 'wp_ajax_dismiss_admin_notice', function () {
 		$dismissible_length = time() + strtotime( absint( $dismissible_length ) . 'days' );
 	}
 
-	if ( wp_verify_nonce( $_REQUEST['nonce'], 'pp-dismissible-notice' ) && false !== strpos( $option_name, 'data-' ) ) {
+	if ( is_integer( wp_verify_nonce( $_REQUEST['nonce'], 'dismissible-notice' ) ) && ( false !== strpos( $option_name, 'data-' ) ) ) {
 		add_option( $option_name, $dismissible_length );
 	}
 
-	add_option( $option_name, $dismissible_length );
 	wp_die();
 } );

--- a/persist-admin-notices-dismissal.php
+++ b/persist-admin-notices-dismissal.php
@@ -70,7 +70,7 @@ add_action( 'admin_enqueue_scripts', function () {
 
 	wp_localize_script( 'dismissible-notices', 'dismissible_notice',
 		array(
-			'nonce' => wp_create_nonce( 'dismissible-notice' ),
+			'nonce' => wp_create_nonce( 'PAnD-dismissible-notice' ),
 		)
 	);
 } );
@@ -86,7 +86,7 @@ add_action( 'wp_ajax_dismiss_admin_notice', function () {
 		$dismissible_length = time() + strtotime( absint( $dismissible_length ) . 'days' );
 	}
 
-	if ( is_integer( wp_verify_nonce( $_REQUEST['nonce'], 'dismissible-notice' ) ) && ( false !== strpos( $option_name, 'data-' ) ) ) {
+	if ( is_integer( wp_verify_nonce( $_REQUEST['nonce'], 'PAnD-dismissible-notice' ) ) && ( false !== strpos( $option_name, 'data-' ) ) ) {
 		add_option( $option_name, $dismissible_length );
 	}
 

--- a/persist-admin-notices-dismissal.php
+++ b/persist-admin-notices-dismissal.php
@@ -57,7 +57,7 @@ if ( ! class_exists( 'PAnD' ) ) {
 		/**
 		 * Enqueue javascript and variables.
 		 */
-		public function load_script() {
+		public static function load_script() {
 			wp_enqueue_script(
 				'dismissible-notices',
 				plugins_url( 'dismiss-notice.js', __FILE__ ),
@@ -79,7 +79,7 @@ if ( ! class_exists( 'PAnD' ) ) {
 		 * Handles Ajax request to persist notices dismissal.
 		 * Uses check_ajax_referer to verify nonce.
 		 */
-		public function dismiss_admin_notice() {
+		public static function dismiss_admin_notice() {
 			$option_name        = sanitize_text_field( $_POST['option_name'] );
 			$dismissible_length = sanitize_text_field( $_POST['dismissible_length'] );
 

--- a/persist-admin-notices-dismissal.php
+++ b/persist-admin-notices-dismissal.php
@@ -107,7 +107,7 @@ if ( ! class_exists( 'PAnD' ) ) {
 			}
 
 			check_ajax_referer( 'PAnD-dismissible-notice', 'nonce', true );
-			add_option( $option_name, $dismissible_length );
+			update_option( $option_name, $dismissible_length );
 			wp_die();
 		}
 

--- a/persist-admin-notices-dismissal.php
+++ b/persist-admin-notices-dismissal.php
@@ -106,10 +106,8 @@ if ( ! class_exists( 'PAnD' ) ) {
 				$dismissible_length = strtotime( absint( $dismissible_length ) . ' days' );
 			}
 
-			if ( false !== wp_verify_nonce( $_REQUEST['nonce'], 'PAnD-dismissible-notice' ) ) {
-				add_option( $option_name, $dismissible_length );
-			}
-
+			check_ajax_referer( 'PAnD-dismissible-notice', 'nonce', true );
+			add_option( $option_name, $dismissible_length );
 			wp_die();
 		}
 

--- a/persist-admin-notices-dismissal.php
+++ b/persist-admin-notices-dismissal.php
@@ -25,6 +25,9 @@
 
 if ( ! class_exists( 'PAnD' ) ) {
 
+	/**
+	 * Class PAnD
+	 */
 	class PAnD {
 
 		/**

--- a/persist-admin-notices-dismissal.php
+++ b/persist-admin-notices-dismissal.php
@@ -97,6 +97,7 @@ if ( ! class_exists( 'PAnD' ) ) {
 
 		/**
 		 * Handles Ajax request to persist notices dismissal.
+		 * Uses check_ajax_referer to verify nonce.
 		 */
 		public function dismiss_admin_notice() {
 			$option_name        = sanitize_text_field( $_POST['option_name'] );
@@ -106,7 +107,7 @@ if ( ! class_exists( 'PAnD' ) ) {
 				$dismissible_length = strtotime( absint( $dismissible_length ) . ' days' );
 			}
 
-			check_ajax_referer( 'PAnD-dismissible-notice', 'nonce', true );
+			check_ajax_referer( 'PAnD-dismissible-notice', 'nonce' );
 			update_option( $option_name, $dismissible_length );
 			wp_die();
 		}
@@ -122,8 +123,7 @@ if ( ! class_exists( 'PAnD' ) ) {
 			$array       = explode( '-', $arg );
 			$length      = array_pop( $array );
 			$option_name = implode( '-', $array );
-
-			$db_record = get_option( $option_name );
+			$db_record   = get_option( $option_name );
 
 			if ( 'forever' == $db_record ) {
 				return false;

--- a/persist-admin-notices-dismissal.php
+++ b/persist-admin-notices-dismissal.php
@@ -49,9 +49,9 @@ if ( ! class_exists( 'PAnD' ) ) {
 		/**
 		 * Init hooks.
 		 */
-		public function init() {
-			add_action( 'admin_enqueue_scripts', array( $this, 'load_script' ) );
-			add_action( 'wp_ajax_dismiss_admin_notice', array( $this, 'dismiss_admin_notice' ) );
+		public static function init() {
+			add_action( 'admin_enqueue_scripts', array( __CLASS__, 'load_script' ) );
+			add_action( 'wp_ajax_dismiss_admin_notice', array( __CLASS__, 'dismiss_admin_notice' ) );
 		}
 
 		/**

--- a/persist-admin-notices-dismissal.php
+++ b/persist-admin-notices-dismissal.php
@@ -103,7 +103,7 @@ if ( ! class_exists( 'PAnD' ) ) {
 			$dismissible_length = sanitize_text_field( $_POST['dismissible_length'] );
 
 			if ( 'forever' != $dismissible_length ) {
-				$dismissible_length = time() + strtotime( absint( $dismissible_length ) . 'days' );
+				$dismissible_length = strtotime( absint( $dismissible_length ) . ' days' );
 			}
 
 			if ( is_integer( wp_verify_nonce( $_REQUEST['nonce'], 'PAnD-dismissible-notice' ) ) && ( false !== strpos( $option_name, 'data-' ) ) ) {

--- a/persist-admin-notices-dismissal.php
+++ b/persist-admin-notices-dismissal.php
@@ -106,7 +106,7 @@ if ( ! class_exists( 'PAnD' ) ) {
 				$dismissible_length = strtotime( absint( $dismissible_length ) . ' days' );
 			}
 
-			if ( is_integer( wp_verify_nonce( $_REQUEST['nonce'], 'PAnD-dismissible-notice' ) ) && ( false !== strpos( $option_name, 'data-' ) ) ) {
+			if ( false !== wp_verify_nonce( $_REQUEST['nonce'], 'PAnD-dismissible-notice' ) ) {
 				add_option( $option_name, $dismissible_length );
 			}
 

--- a/persist-admin-notices-dismissal.php
+++ b/persist-admin-notices-dismissal.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Persist Admin notices Dismissal
  *
@@ -18,67 +19,79 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  * @package Persist Admin notices Dismissal
- * @author Agbonghama Collins
+ * @author  Agbonghama Collins
  * @license http://www.gnu.org/licenses GNU General Public License
  */
 
+if ( ! class_exists( 'PAnD' ) ) {
 
-add_action('admin_enqueue_scripts', function () {
-    wp_enqueue_script('dismissible-notices',
-        plugin_dir_url(__FILE__) . 'dismiss-notice.js',
-        false,
-        true
-    );
+	class PAnD {
 
-    wp_localize_script('dismissible-notices', 'dismissible_notice',
-        array(
-            'nonce' => wp_create_nonce('dismissible-notice'),
-        )
-    );
-});
+		public function __construct() {
 
+			/**
+			 * Enqueue javascript and register tags.
+			 */
+			add_action( 'admin_enqueue_scripts', function () {
+				wp_enqueue_script( 'dismissible-notices',
+					plugin_dir_url( __FILE__ ) . 'dismiss-notice.js',
 					array( 'jquery', 'common' ),
+					false,
+					true
+				);
 
-/**
- * Handles Ajax request to persist notices dismissal.
- */
-add_action('wp_ajax_dismiss_admin_notice', function () {
-    $option_name        = sanitize_text_field($_POST['option_name']);
-    $dismissible_length = sanitize_text_field($_POST['dismissible_length']);
-
-    if ($dismissible_length != 'forever') {
-        $dismissible_length = time() + strtotime(absint($dismissible_length) . 'days');
-    }
-
-    if (wp_verify_nonce($_REQUEST['nonce'], 'pp-dismissible-notice') && strpos($option_name, 'data-') !== false) {
-        add_option($option_name, $dismissible_length);
-    }
-
-    add_option($option_name, $dismissible_length);
-    wp_die();
-});
+				wp_localize_script( 'dismissible-notices', 'dismissible_notice',
+					array(
+						'nonce' => wp_create_nonce( 'dismissible-notice' ),
+					)
+				);
+			} );
 
 
-/**
- * Is admin notice active?
- *
- * @param string $arg
- *
- * @return bool
- */
-function is_admin_notice_active($arg)
-{
-    $array       = explode('-', $arg);
-    $length      = array_pop($array);
-    $option_name = implode('-', $array);
+			/**
+			 * Handles Ajax request to persist notices dismissal.
+			 */
+			add_action( 'wp_ajax_dismiss_admin_notice', function () {
+				$option_name        = sanitize_text_field( $_POST['option_name'] );
+				$dismissible_length = sanitize_text_field( $_POST['dismissible_length'] );
 
-    $db_record = get_option($option_name);
+				if ( 'forever' != $dismissible_length ) {
+					$dismissible_length = time() + strtotime( absint( $dismissible_length ) . 'days' );
+				}
 
-    if ($db_record == 'forever') {
-        return false;
-    } elseif (absint($db_record) >= time()) {
-        return false;
-    } else {
-        return true;
-    }
+				if ( wp_verify_nonce( $_REQUEST['nonce'], 'pp-dismissible-notice' ) && false !== strpos( $option_name, 'data-' ) ) {
+					add_option( $option_name, $dismissible_length );
+				}
+
+				add_option( $option_name, $dismissible_length );
+				wp_die();
+			} );
+		}
+
+		/**
+		 * Is admin notice active?
+		 *
+		 * @param string $arg
+		 *
+		 * @return bool
+		 */
+		public function is_admin_notice_active( $arg ) {
+			$array       = explode( '-', $arg );
+			$length      = array_pop( $array );
+			$option_name = implode( '-', $array );
+
+			$db_record = get_option( $option_name );
+
+			if ( 'forever' == $db_record ) {
+				return false;
+			} elseif ( absint( $db_record ) >= time() ) {
+				return false;
+			} else {
+				return true;
+			}
+		}
+
+	}
+
+	new PAnD();
 }

--- a/persist-admin-notices-dismissal.php
+++ b/persist-admin-notices-dismissal.php
@@ -20,7 +20,9 @@
  *
  * @package Persist Admin notices Dismissal
  * @author  Agbonghama Collins
+ * @author  Andy Fragen
  * @license http://www.gnu.org/licenses GNU General Public License
+ * @version 1.0.0
  */
 
 /**

--- a/persist-admin-notices-dismissal.php
+++ b/persist-admin-notices-dismissal.php
@@ -47,26 +47,6 @@ if ( ! class_exists( 'PAnD' ) ) {
 	class PAnD {
 
 		/**
-		 * Singleton variable.
-		 *
-		 * @var bool
-		 */
-		private static $instance = false;
-
-		/**
-		 * Singleton.
-		 *
-		 * @return bool|\PAnD
-		 */
-		public static function instance() {
-			if ( false === self::$instance ) {
-				self::$instance = new self();
-			}
-
-			return self::$instance;
-		}
-
-		/**
 		 * Init hooks.
 		 */
 		public function init() {

--- a/persist-admin-notices-dismissal.php
+++ b/persist-admin-notices-dismissal.php
@@ -26,7 +26,6 @@
 add_action('admin_enqueue_scripts', function () {
     wp_enqueue_script('dismissible-notices',
         plugin_dir_url(__FILE__) . 'dismiss-notice.js',
-        ['jquery', 'common'],
         false,
         true
     );
@@ -38,6 +37,7 @@ add_action('admin_enqueue_scripts', function () {
     );
 });
 
+					array( 'jquery', 'common' ),
 
 /**
  * Handles Ajax request to persist notices dismissal.

--- a/persist-admin-notices-dismissal.php
+++ b/persist-admin-notices-dismissal.php
@@ -22,7 +22,7 @@
  * @author  Agbonghama Collins
  * @author  Andy Fragen
  * @license http://www.gnu.org/licenses GNU General Public License
- * @version 1.0.0
+ * @version 1.1.0
  */
 
 /**


### PR DESCRIPTION
I've done a large refactor of the library by putting it in a class. This has a couple of advantanges. Below is a summary of the changes.
- this will allow Composer to use it's autoloader for the class
- added exits for direct calling of class, calling during heartbeat, and if `class_exists()`
- I included a `.gitattributes` file to exclude dev stuff from a direct download.
- I updated the README to refer to a framework library and updated the examples.
- spacing per WP Coding Guidelines.
- switched to Yoda conditionals.
- removed anonymous functions and shorthand array declaration, it should be PHP 5.2 compatible now. Since we didn't use namespacing there's not much need to limit ourselves.
- fixed the nonce check so it works 👍 
- in the Docblock, I added myself as an author and included a version number

You've done a great job, thanks!

Let me know if there is anything else I can do for the PR or if this really isn't the direction you wanted to go.

BTW, I'm not really good with `composer.json` and I don't know if any changes need to be made there.
