### PR TITLE
Use options not transients

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,6 @@
+#### 1.4.0
+* WPCS 1.1.0 linting done
+* switched from storing timeout in transients to storing in the options table, this should play much better with object caching
+
+#### 1.3.x
+* uses transients to store timeout

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ function sample_admin_notice__success() {
 	if ( ! PAnD::is_admin_notice_active( 'disable-done-notice-forever' ) ) {
 		return;
 	}
-	
+
 	?>
 	<div data-dismissible="disable-done-notice-forever" class="updated notice notice-success is-dismissible">
 		<p><?php _e( 'Done!', 'sample-text-domain' ); ?></p>
@@ -61,7 +61,7 @@ Just add the following in your main plugin file.
 ```php
 add_action( 'admin_init', array( 'PAnD', 'init' ) );
 ```
- 
+
 #### Usage Instructions and Examples
 If you have two notices displayed when certain actions are triggered; firstly, choose a string to uniquely identify them, e.g. `notice-one` and `notice-two`
 

--- a/README.md
+++ b/README.md
@@ -104,5 +104,14 @@ add_action( 'admin_notices', 'sample_admin_notice__success1' );
 add_action( 'admin_notices', 'sample_admin_notice__success2' );
 ```
 
+You should be a good developer and add the following to your `uninstall.php` file so that we can clean up after ourselves and not leave unnecessary stuff in the options table.
+
+```php
+global $wpdb;
+$table         = is_multisite() ? $wpdb->base_prefix . 'sitemeta' : $wpdb->base_prefix . 'options';
+$column        = is_multisite() ? 'meta_key' : 'option_name';
+$delete_string = 'DELETE FROM ' . $table . ' WHERE ' . $column . ' LIKE %s LIMIT 1000';
+$wpdb->query( $wpdb->prepare( $delete_string, array( '%pand-%' ) ) );
+```
 
 Cool beans. Isn't it?

--- a/dismiss-notice.js
+++ b/dismiss-notice.js
@@ -1,29 +1,33 @@
 (function ($) {
-    //shorthand for ready event.
-    $(function () {
-        $('div[data-dismissible] button.notice-dismiss').click(function (event) {
-            event.preventDefault();
-            var $this = $(this);
+	//shorthand for ready event.
+	$(
+		function () {
+			$( 'div[data-dismissible] button.notice-dismiss' ).click(
+				function (event) {
+					event.preventDefault();
+					var $this = $( this );
 
-            var attr_value, option_name, dismissible_length, data;
+					var attr_value, option_name, dismissible_length, data;
 
-            attr_value = $this.parent().attr('data-dismissible').split('-');
+					attr_value = $this.parent().attr( 'data-dismissible' ).split( '-' );
 
-            // remove the dismissible length from the attribute value and rejoin the array.
-            dismissible_length = attr_value.pop();
+					// remove the dismissible length from the attribute value and rejoin the array.
+					dismissible_length = attr_value.pop();
 
-            option_name = attr_value.join('-');
+					option_name = attr_value.join( '-' );
 
-            data = {
-                'action': 'dismiss_admin_notice',
-                'option_name': option_name,
-                'dismissible_length': dismissible_length,
-                'nonce': dismissible_notice.nonce
-            };
+					data = {
+						'action': 'dismiss_admin_notice',
+						'option_name': option_name,
+						'dismissible_length': dismissible_length,
+						'nonce': dismissible_notice.nonce
+					};
 
-            // We can also pass the url value separately from ajaxurl for front end AJAX implementations
-            $.post(ajaxurl, data);
-        });
-    })
+					// We can also pass the url value separately from ajaxurl for front end AJAX implementations
+					$.post( ajaxurl, data );
+				}
+			);
+		}
+	)
 
 }(jQuery));

--- a/persist-admin-notices-dismissal.php
+++ b/persist-admin-notices-dismissal.php
@@ -22,7 +22,7 @@
  * @author  Agbonghama Collins
  * @author  Andy Fragen
  * @license http://www.gnu.org/licenses GNU General Public License
- * @version 1.3.2
+ * @version 1.4.0
  */
 
 /**

--- a/persist-admin-notices-dismissal.php
+++ b/persist-admin-notices-dismissal.php
@@ -52,7 +52,9 @@ if ( ! class_exists( 'PAnD' ) ) {
 		 */
 		public static function load_script() {
 
-		    if(is_customize_preview()) return;
+			if ( is_customize_preview() ) {
+				return;
+			}
 
 			wp_enqueue_script(
 				'dismissible-notices',
@@ -78,17 +80,15 @@ if ( ! class_exists( 'PAnD' ) ) {
 		public static function dismiss_admin_notice() {
 			$option_name        = sanitize_text_field( $_POST['option_name'] );
 			$dismissible_length = sanitize_text_field( $_POST['dismissible_length'] );
-			$transient          = 0;
 
 			if ( 'forever' != $dismissible_length ) {
 				// If $dismissible_length is not an integer default to 1
 				$dismissible_length = ( 0 == absint( $dismissible_length ) ) ? 1 : $dismissible_length;
-				$transient          = absint( $dismissible_length ) * DAY_IN_SECONDS;
 				$dismissible_length = strtotime( absint( $dismissible_length ) . ' days' );
 			}
 
 			check_ajax_referer( 'dismissible-notice', 'nonce' );
-			set_site_transient( $option_name, $dismissible_length, $transient );
+			self::set_admin_notice_cache( $option_name, $dismissible_length );
 			wp_die();
 		}
 
@@ -103,7 +103,7 @@ if ( ! class_exists( 'PAnD' ) ) {
 			$array       = explode( '-', $arg );
 			$length      = array_pop( $array );
 			$option_name = implode( '-', $array );
-			$db_record   = get_site_transient( $option_name );
+			$db_record   = self::get_admin_notice_cache( $option_name );
 
 			if ( 'forever' == $db_record ) {
 				return false;
@@ -112,6 +112,46 @@ if ( ! class_exists( 'PAnD' ) ) {
 			} else {
 				return true;
 			}
+		}
+
+		/**
+		 * Returns admin notice cached timeout.
+		 *
+		 * @access public
+		 *
+		 * @param string|bool $id admin notice name or false.
+		 *
+		 * @return array|bool The timeout. False if expired.
+		 */
+		public static function get_admin_notice_cache( $id = false ) {
+			if ( ! $id ) {
+				return false;
+			}
+			$cache_key = 'pand-' . md5( $id );
+			$timeout   = get_site_option( $cache_key );
+
+			if ( empty( $timeout ) || time() > $timeout ) {
+				return false;
+			}
+
+			return $timeout;
+		}
+
+		/**
+		 * Sets admin notice timeout in site option.
+		 *
+		 * @access public
+		 *
+		 * @param string      $id       Data Identifier.
+		 * @param string|bool $timeout  Timeout for admin notice.
+		 *
+		 * @return bool
+		 */
+		public static function set_admin_notice_cache( $id, $timeout ) {
+			$cache_key = 'pand-' . md5( $id );
+			update_site_option( $cache_key, $timeout );
+
+			return true;
 		}
 
 	}


### PR DESCRIPTION
Hopefully this plays nicer with object caching.
Fixes https://github.com/collizo4sky/persist-admin-notices-dismissal/issues/17