### PR TITLE
update .gitattributes .gitignore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,4 +2,3 @@
 
 .gitattributes export-ignore
 .gitignore export-ignore
-composer.json export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 .idea
 .vs-code
+vendor/*

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea
 .vs-code
 vendor/*
+/vendor/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-vendor/*
-/vendor/
-.idea/*
-index.php
+.DS_Store
+.idea
+.vs-code

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+#### 1.4.2
+* No changes to `class PAnD`
+* updated `.gitignore` and `.gitattributes`
+* now use classmap in composer's autoloader, should be more efficient
+
 #### 1.4.1
 * fixed the `forever` setting with options
 

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         }
     ],
     "autoload": {
-        "files": [
+        "classmap": [
             "persist-admin-notices-dismissal.php"
         ]
     }


### PR DESCRIPTION
Fixes https://github.com/collizo4sky/persist-admin-notices-dismissal/issues/23

Cleans up these 2 files, removing some unneeded stuff and allowing composer.json to be downloaded