### PR TITLE
add js url filter hook

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 #### 1.4.3
-* added filter hook `pand_dismiss_notice_js_url` in case you're using this in a theme or a local environment that doesn't quite find the correct URL
+* added filter hook `pand_dismiss_notice_js_url` in case you're using this in a theme or a local environment that doesn't quite find the correct URL.
+* added filter hook `pand_theme_loader` that returns a boolean for simpler usage of the `pand_dismiss_notice_js_url` hook
 
 #### 1.4.2
 * No changes to `class PAnD`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+#### 1.4.3
+* added filter hook `pand_dismiss_notice_js_url` in case you're using this in a theme or a local environment that doesn't quite find the correct URL
+
 #### 1.4.2
 * No changes to `class PAnD`
 * updated `.gitignore` and `.gitattributes`

--- a/README.md
+++ b/README.md
@@ -109,6 +109,12 @@ Please note that if you cleanup after your plugin deletion please try to make th
 A filter hook is available to return the proper URL to the Javascript file. An example usage is as follows, especially if this is being used in a theme.
 
 ```php
+add_filter( 'pand_theme_loader', '__return_true' );
+```
+
+The `pand_theme_loader` runs the following hook if `true`. You can directly change the URL to the Javascript file by using another hook in the following manner by changing the return value.
+
+```php
 add_filter(
 	'pand_dismiss_notice_js_url',
 	function( $js_url, $composer_path ) {

--- a/README.md
+++ b/README.md
@@ -106,4 +106,17 @@ add_action( 'admin_notices', 'sample_admin_notice__success2' );
 
 Please note that if you cleanup after your plugin deletion please try to make the removal of stored options as specific as possible. Otherwise you may end up deleting the stored options from other projects.
 
+A filter hook is available to return the proper URL to the Javascript file. An example usage is as follows, especially if this is being used in a theme.
+
+```php
+add_filter(
+	'pand_dismiss_notice_js_url',
+	function( $js_url, $composer_path ) {
+		return get_stylesheet_directory_uri() . $composer_path;
+	},
+	10,
+	2
+);
+```
+
 Cool beans. Isn't it?

--- a/persist-admin-notices-dismissal.php
+++ b/persist-admin-notices-dismissal.php
@@ -45,6 +45,24 @@ if ( ! class_exists( 'PAnD' ) ) {
 		public static function init() {
 			add_action( 'admin_enqueue_scripts', array( __CLASS__, 'load_script' ) );
 			add_action( 'wp_ajax_dismiss_admin_notice', array( __CLASS__, 'dismiss_admin_notice' ) );
+
+			/**
+			 * Filter to activate another filter providing a simpler use case.
+			 *
+			 * @since 1.4.3
+			 *
+			 * @param bool
+			 */
+			if ( apply_filters( 'pand_theme_loader', false ) ) {
+				add_filter(
+					'pand_dismiss_notice_js_url',
+					function( $js_url, $composer_path ) {
+						return get_stylesheet_directory_uri() . $composer_path;
+					},
+					10,
+					2
+				);
+			}
 		}
 
 		/**

--- a/persist-admin-notices-dismissal.php
+++ b/persist-admin-notices-dismissal.php
@@ -22,7 +22,7 @@
  * @author  Collins Agbonghama
  * @author  Andy Fragen
  * @license http://www.gnu.org/licenses GNU General Public License
- * @version 1.4.2
+ * @version 1.4.3
  */
 
 /**
@@ -56,9 +56,19 @@ if ( ! class_exists( 'PAnD' ) ) {
 				return;
 			}
 
+			$js_url        = plugins_url( 'dismiss-notice.js', __FILE__ );
+			$composer_path = '/vendor/collizo4sky/persist-admin-notices-dismissal/dismiss-notice.js';
+
+			/**
+			 * Filter dismiss-notice.js URL.
+			 *
+			 * @param string $js_url URL to the Javascript file.
+			 * @param string $composer_path Relative path of Javascript file from composer install.
+			 */
+			$js_url = apply_filters( 'pand_dismiss_notice_js_url', $js_url, $composer_path );
 			wp_enqueue_script(
 				'dismissible-notices',
-				plugins_url( 'dismiss-notice.js', __FILE__ ),
+				$js_url,
 				array( 'jquery', 'common' ),
 				false,
 				true

--- a/persist-admin-notices-dismissal.php
+++ b/persist-admin-notices-dismissal.php
@@ -62,6 +62,8 @@ if ( ! class_exists( 'PAnD' ) ) {
 			/**
 			 * Filter dismiss-notice.js URL.
 			 *
+			 * @since 1.4.3
+			 *
 			 * @param string $js_url URL to the Javascript file.
 			 * @param string $composer_path Relative path of Javascript file from composer install.
 			 */


### PR DESCRIPTION
We hard-coded the plugin URL. If this framework is used in a theme the JS won't be loaded. This hook allows for a simple method of returning a correct URL for enqueuing the JS file.

Hopefully, this fixes https://github.com/afragen/wp-dependency-installer/issues/29