### PR TITLE
Extra dismiss links

### DIFF
--- a/dismiss-notice.js
+++ b/dismiss-notice.js
@@ -2,7 +2,7 @@
 	//shorthand for ready event.
 	$(
 		function () {
-			$( 'div[data-dismissible] button.notice-dismiss, div[data-dismissible] .dismiss-this' ).click(
+			$( 'div[data-dismissible] button.notice-dismiss, div[data-dismissible] .dismiss-this' ).on("click",
 				function (event) {
 					event.preventDefault();
 					var $this = $( this );

--- a/dismiss-notice.js
+++ b/dismiss-notice.js
@@ -9,7 +9,7 @@
 
 					var attr_value, option_name, dismissible_length, data;
 
-					attr_value = $this.parent().attr( 'data-dismissible' ).split( '-' );
+					attr_value = $this.closest("div[data-dismissible]").attr( 'data-dismissible' ).split( '-' );
 
 					// remove the dismissible length from the attribute value and rejoin the array.
 					dismissible_length = attr_value.pop();
@@ -25,6 +25,7 @@
 
 					// We can also pass the url value separately from ajaxurl for front end AJAX implementations
 					$.post( ajaxurl, data );
+					$this.closest("div[data-dismissible]").hide('slow');
 				}
 			);
 		}

--- a/dismiss-notice.js
+++ b/dismiss-notice.js
@@ -2,7 +2,7 @@
 	//shorthand for ready event.
 	$(
 		function () {
-			$( 'div[data-dismissible] button.notice-dismiss, div[data-dismissible] notice-dismiss' ).click(
+			$( 'div[data-dismissible] button.notice-dismiss, div[data-dismissible] .notice-dismiss' ).click(
 				function (event) {
 					event.preventDefault();
 					var $this = $( this );

--- a/dismiss-notice.js
+++ b/dismiss-notice.js
@@ -2,7 +2,7 @@
 	//shorthand for ready event.
 	$(
 		function () {
-			$( 'div[data-dismissible] button.notice-dismiss, div[data-dismissible] .notice-dismiss' ).click(
+			$( 'div[data-dismissible] button.notice-dismiss, div[data-dismissible] .dismiss-this' ).click(
 				function (event) {
 					event.preventDefault();
 					var $this = $( this );

--- a/dismiss-notice.js
+++ b/dismiss-notice.js
@@ -2,7 +2,7 @@
 	//shorthand for ready event.
 	$(
 		function () {
-			$( 'div[data-dismissible] button.notice-dismiss' ).click(
+			$( 'div[data-dismissible] button.notice-dismiss, div[data-dismissible] notice-dismiss' ).click(
 				function (event) {
 					event.preventDefault();
 					var $this = $( this );


### PR DESCRIPTION
Minor changes to .js file allows you to add links inside the div itself to dismiss the notification, not only by clicking the close button.

Any element with class "dismiss-this" can be clicked and will close the div.