### PR TITLE
WPCS fixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+#### 1.4.5
+* WPCS fixes.
+
 #### 1.4.4
 * Added support for extra dismissible links via `.dismiss-this` CSS class.
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "collizo4sky/persist-admin-notices-dismissal",
     "description": "Simple library to persist dismissal of admin notices across pages in WordPress dashboard.",
-    "version": "1.4.4",
+    "version": "1.4.5",
     "type": "library",
     "license": "GPL-3.0-or-later",
     "authors": [

--- a/persist-admin-notices-dismissal.php
+++ b/persist-admin-notices-dismissal.php
@@ -87,7 +87,7 @@ if ( ! class_exists( 'PAnD' ) ) {
 				'dismissible-notices',
 				$js_url,
 				array( 'jquery', 'common' ),
-				false,
+				'1.4.5',
 				true
 			);
 

--- a/persist-admin-notices-dismissal.php
+++ b/persist-admin-notices-dismissal.php
@@ -89,7 +89,7 @@ if ( ! class_exists( 'PAnD' ) ) {
 				'dismissible-notices',
 				$js_url,
 				array( 'jquery', 'common' ),
-				false,
+				'1.4.4',
 				true
 			);
 
@@ -107,8 +107,8 @@ if ( ! class_exists( 'PAnD' ) ) {
 		 * Uses check_ajax_referer to verify nonce.
 		 */
 		public static function dismiss_admin_notice() {
-			$option_name        = sanitize_text_field( $_POST['option_name'] );
-			$dismissible_length = sanitize_text_field( $_POST['dismissible_length'] );
+			$option_name        = !empty( $_POST['option_name'] ) ? sanitize_text_field( $_POST['option_name'] ) : '';
+			$dismissible_length = !empty( $_POST['dismissible_length'] ) ? sanitize_text_field( $_POST['dismissible_length'] ) : '';
 
 			if ( 'forever' != $dismissible_length ) {
 				// If $dismissible_length is not an integer default to 1


### PR DESCRIPTION
Version parameter is not explicitly set or has been set to an equivalent of "false" for wp_enqueue_script; This means that the WordPress core version will be used which is not recommended for plugin or theme development. (WordPress.WP.EnqueuedResourceParameters.NoExplicitVersion)